### PR TITLE
Samples: Bluetooth: Update authentication callbacks

### DIFF
--- a/samples/bluetooth/central_and_peripheral_hr/src/main.c
+++ b/samples/bluetooth/central_and_peripheral_hr/src/main.c
@@ -200,9 +200,12 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 }
 
 static const struct bt_conn_auth_cb auth_callbacks = {
-	.pairing_complete = pairing_complete,
-	.pairing_failed = pairing_failed,
 	.cancel = auth_cancel
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
+	.pairing_complete = pairing_complete,
+	.pairing_failed = pairing_failed
 };
 
 static int scan_start(void)
@@ -381,7 +384,17 @@ void main(void)
 		return;
 	}
 
-	bt_conn_auth_cb_register(&auth_callbacks);
+	err = bt_conn_auth_cb_register(&auth_callbacks);
+	if (err) {
+		printk("Failed to register authorization callbacks.\n");
+		return;
+	}
+
+	err = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+	if (err) {
+		printk("Failed to register authorization info callbacks.\n");
+		return;
+	}
 
 	err = bt_enable(NULL);
 	if (err) {

--- a/samples/bluetooth/central_bas/src/main.c
+++ b/samples/bluetooth/central_bas/src/main.c
@@ -353,6 +353,9 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 
 static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.cancel = auth_cancel,
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed
 };
@@ -383,6 +386,12 @@ void main(void)
 	err = bt_conn_auth_cb_register(&conn_auth_callbacks);
 	if (err) {
 		printk("Failed to register authorization callbacks.\n");
+		return;
+	}
+
+	err = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+	if (err) {
+		printk("Failed to register authorization info callbacks.\n");
 		return;
 	}
 

--- a/samples/bluetooth/central_hids/src/main.c
+++ b/samples/bluetooth/central_hids/src/main.c
@@ -627,6 +627,9 @@ static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.passkey_display = auth_passkey_display,
 	.passkey_confirm = auth_passkey_confirm,
 	.cancel = auth_cancel,
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed
 };
@@ -643,6 +646,12 @@ void main(void)
 	err = bt_conn_auth_cb_register(&conn_auth_callbacks);
 	if (err) {
 		printk("failed to register authorization callbacks.\n");
+		return;
+	}
+
+	err = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+	if (err) {
+		printk("Failed to register authorization info callbacks.\n");
 		return;
 	}
 

--- a/samples/bluetooth/central_nfc_pairing/src/main.c
+++ b/samples/bluetooth/central_nfc_pairing/src/main.c
@@ -332,6 +332,9 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.cancel = auth_cancel,
 	.oob_data_request = auth_oob_data_request,
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed
 };
@@ -608,6 +611,12 @@ void main(void)
 	err = bt_conn_auth_cb_register(&conn_auth_callbacks);
 	if (err) {
 		printk("Failed to register authorization callbacks.\n");
+		return;
+	}
+
+	err = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+	if (err) {
+		printk("Failed to register authorization info callbacks.\n");
 		return;
 	}
 

--- a/samples/bluetooth/central_uart/src/main.c
+++ b/samples/bluetooth/central_uart/src/main.c
@@ -552,6 +552,9 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 
 static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.cancel = auth_cancel,
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed
 };
@@ -563,6 +566,12 @@ void main(void)
 	err = bt_conn_auth_cb_register(&conn_auth_callbacks);
 	if (err) {
 		LOG_ERR("Failed to register authorization callbacks.");
+		return;
+	}
+
+	err = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+	if (err) {
+		printk("Failed to register authorization info callbacks.\n");
 		return;
 	}
 

--- a/samples/bluetooth/peripheral_ams_client/src/main.c
+++ b/samples/bluetooth/peripheral_ams_client/src/main.c
@@ -349,6 +349,9 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 
 static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.cancel = auth_cancel,
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed
 };
@@ -465,6 +468,12 @@ void main(void)
 	err = bt_conn_auth_cb_register(&conn_auth_callbacks);
 	if (err) {
 		printk("Failed to register authorization callbacks\n");
+		return;
+	}
+
+	err = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+	if (err) {
+		printk("Failed to register authorization info callbacks.\n");
 		return;
 	}
 

--- a/samples/bluetooth/peripheral_ancs_client/src/main.c
+++ b/samples/bluetooth/peripheral_ancs_client/src/main.c
@@ -400,6 +400,9 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 
 static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.cancel = auth_cancel,
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed
 };
@@ -709,6 +712,12 @@ void main(void)
 	err = bt_conn_auth_cb_register(&conn_auth_callbacks);
 	if (err) {
 		printk("Failed to register authorization callbacks\n");
+		return;
+	}
+
+	err = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+	if (err) {
+		printk("Failed to register authorization info callbacks.\n");
 		return;
 	}
 

--- a/samples/bluetooth/peripheral_bms/src/main.c
+++ b/samples/bluetooth/peripheral_bms/src/main.c
@@ -128,6 +128,9 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.passkey_display = auth_passkey_display,
 	.cancel = auth_cancel,
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed
 };
@@ -183,7 +186,17 @@ void main(void)
 		return;
 	}
 
-	bt_conn_auth_cb_register(&conn_auth_callbacks);
+	err = bt_conn_auth_cb_register(&conn_auth_callbacks);
+	if (err) {
+		printk("Failed to register authorization callbacks.\n");
+		return;
+	}
+
+	err = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+	if (err) {
+		printk("Failed to register authorization info callbacks.\n");
+		return;
+	}
 
 	err = bt_enable(NULL);
 	if (err) {

--- a/samples/bluetooth/peripheral_cts_client/src/main.c
+++ b/samples/bluetooth/peripheral_cts_client/src/main.c
@@ -249,6 +249,9 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 
 static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.cancel = auth_cancel,
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed
 };
@@ -332,6 +335,12 @@ void main(void)
 	err = bt_conn_auth_cb_register(&conn_auth_callbacks);
 	if (err) {
 		printk("Failed to register authorization callbacks\n");
+		return;
+	}
+
+	err = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+	if (err) {
+		printk("Failed to register authorization info callbacks.\n");
 		return;
 	}
 

--- a/samples/bluetooth/peripheral_gatt_dm/src/main.c
+++ b/samples/bluetooth/peripheral_gatt_dm/src/main.c
@@ -168,6 +168,9 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.cancel = auth_cancel,
 	.pairing_confirm = pairing_confirm,
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed
 };
@@ -232,6 +235,12 @@ void main(void)
 	err = bt_conn_auth_cb_register(&conn_auth_callbacks);
 	if (err) {
 		printk("Failed to register authorization callbacks.\n");
+		return;
+	}
+
+	err = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+	if (err) {
+		printk("Failed to register authorization info callbacks.\n");
 		return;
 	}
 

--- a/samples/bluetooth/peripheral_hids_keyboard/src/main.c
+++ b/samples/bluetooth/peripheral_hids_keyboard/src/main.c
@@ -622,6 +622,9 @@ static struct bt_conn_auth_cb conn_auth_callbacks = {
 #if CONFIG_NFC_OOB_PAIRING
 	.oob_data_request = auth_oob_data_request,
 #endif
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed
 };
@@ -937,7 +940,17 @@ void main(void)
 
 	configure_gpio();
 
-	bt_conn_auth_cb_register(&conn_auth_callbacks);
+	err = bt_conn_auth_cb_register(&conn_auth_callbacks);
+	if (err) {
+		printk("Failed to register authorization callbacks.\n");
+		return;
+	}
+
+	err = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+	if (err) {
+		printk("Failed to register authorization info callbacks.\n");
+		return;
+	}
 
 	err = bt_enable(NULL);
 	if (err) {

--- a/samples/bluetooth/peripheral_hids_mouse/src/main.c
+++ b/samples/bluetooth/peripheral_hids_mouse/src/main.c
@@ -631,6 +631,9 @@ static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.passkey_display = auth_passkey_display,
 	.passkey_confirm = auth_passkey_confirm,
 	.cancel = auth_cancel,
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed
 };
@@ -756,7 +759,17 @@ void main(void)
 	printk("Starting Bluetooth Peripheral HIDS mouse example\n");
 
 	if (IS_ENABLED(CONFIG_BT_HIDS_SECURITY_ENABLED)) {
-		bt_conn_auth_cb_register(&conn_auth_callbacks);
+		err = bt_conn_auth_cb_register(&conn_auth_callbacks);
+		if (err) {
+			printk("Failed to register authorization callbacks.\n");
+			return;
+		}
+
+		err = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+		if (err) {
+			printk("Failed to register authorization info callbacks.\n");
+			return;
+		}
 	}
 
 	err = bt_enable(NULL);

--- a/samples/bluetooth/peripheral_lbs/src/main.c
+++ b/samples/bluetooth/peripheral_lbs/src/main.c
@@ -133,6 +133,9 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.passkey_display = auth_passkey_display,
 	.cancel = auth_cancel,
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed
 };
@@ -197,7 +200,17 @@ void main(void)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_LBS_SECURITY_ENABLED)) {
-		bt_conn_auth_cb_register(&conn_auth_callbacks);
+		err = bt_conn_auth_cb_register(&conn_auth_callbacks);
+		if (err) {
+			printk("Failed to register authorization callbacks.\n");
+			return;
+		}
+
+		err = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+		if (err) {
+			printk("Failed to register authorization info callbacks.\n");
+			return;
+		}
 	}
 
 	err = bt_enable(NULL);

--- a/samples/bluetooth/peripheral_nfc_pairing/src/main.c
+++ b/samples/bluetooth/peripheral_nfc_pairing/src/main.c
@@ -352,9 +352,12 @@ static enum bt_security_err pairing_accept(struct bt_conn *conn,
 static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.cancel = auth_cancel,
 	.oob_data_request = auth_oob_data_request,
-	.pairing_complete = pairing_complete,
-	.pairing_failed = pairing_failed,
 	.pairing_accept = pairing_accept,
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
+	.pairing_complete = pairing_complete,
+	.pairing_failed = pairing_failed
 };
 
 static void connected(struct bt_conn *conn, uint8_t err)
@@ -723,7 +726,17 @@ void main(void)
 		printk("Cannot init buttons (err %d\n", err);
 	}
 
-	bt_conn_auth_cb_register(&conn_auth_callbacks);
+	err = bt_conn_auth_cb_register(&conn_auth_callbacks);
+	if (err) {
+		printk("Failed to register authorization callbacks.\n");
+		return;
+	}
+
+	err = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+	if (err) {
+		printk("Failed to register authorization info callbacks.\n");
+		return;
+	}
 
 	err = bt_enable(NULL);
 	if (err) {

--- a/samples/bluetooth/peripheral_rscs/src/main.c
+++ b/samples/bluetooth/peripheral_rscs/src/main.c
@@ -183,6 +183,9 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.passkey_display = auth_passkey_display,
 	.cancel = auth_cancel,
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed
 };
@@ -210,7 +213,17 @@ void main(void)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_RSCS_SECURITY_ENABLED)) {
-		bt_conn_auth_cb_register(&conn_auth_callbacks);
+		err = bt_conn_auth_cb_register(&conn_auth_callbacks);
+		if (err) {
+			printk("Failed to register authorization callbacks.\n");
+			return;
+		}
+
+		err = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+		if (err) {
+			printk("Failed to register authorization info callbacks.\n");
+			return;
+		}
 	}
 
 	err = bt_enable(NULL);

--- a/samples/bluetooth/peripheral_uart/src/main.c
+++ b/samples/bluetooth/peripheral_uart/src/main.c
@@ -442,6 +442,9 @@ static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.passkey_display = auth_passkey_display,
 	.passkey_confirm = auth_passkey_confirm,
 	.cancel = auth_cancel,
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed
 };
@@ -570,7 +573,17 @@ void main(void)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_NUS_SECURITY_ENABLED)) {
-		bt_conn_auth_cb_register(&conn_auth_callbacks);
+		err = bt_conn_auth_cb_register(&conn_auth_callbacks);
+		if (err) {
+			printk("Failed to register authorization callbacks.\n");
+			return;
+		}
+
+		err = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+		if (err) {
+			printk("Failed to register authorization info callbacks.\n");
+			return;
+		}
 	}
 
 	err = bt_enable(NULL);

--- a/samples/bluetooth/shell_bt_nus/src/main.c
+++ b/samples/bluetooth/shell_bt_nus/src/main.c
@@ -111,6 +111,9 @@ static void pairing_failed(struct bt_conn *conn, enum bt_security_err reason)
 static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.passkey_display = auth_passkey_display,
 	.cancel = auth_cancel,
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed
 };
@@ -122,7 +125,17 @@ void main(void)
 	printk("Starting Bluetooth NUS shell transport example\n");
 
 	if (IS_ENABLED(CONFIG_BT_SMP)) {
-		bt_conn_auth_cb_register(&conn_auth_callbacks);
+		err = bt_conn_auth_cb_register(&conn_auth_callbacks);
+		if (err) {
+			printk("Failed to register authorization callbacks.\n");
+			return;
+		}
+
+		err = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+		if (err) {
+			printk("Failed to register authorization info callbacks.\n");
+			return;
+		}
 	}
 
 	err = bt_enable(NULL);

--- a/samples/openthread/coap_client/src/ble_utils.c
+++ b/samples/openthread/coap_client/src/ble_utils.c
@@ -31,6 +31,9 @@ security_changed(struct bt_conn *conn, bt_security_t level,
 static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.passkey_display = auth_passkey_display,
 	.cancel = auth_cancel,
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed
 };
@@ -143,7 +146,17 @@ int ble_utils_init(struct bt_nus_cb *nus_clbs, ble_connection_cb_t on_connect,
 	bt_conn_cb_register(&conn_callbacks);
 
 	if (IS_ENABLED(CONFIG_BT_SMP)) {
-		bt_conn_auth_cb_register(&conn_auth_callbacks);
+		ret = bt_conn_auth_cb_register(&conn_auth_callbacks);
+		if (ret) {
+			LOG_ERR("Failed to register authorization callbacks.");
+			goto end;
+		}
+
+		ret = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+		if (ret) {
+			LOG_ERR("Failed to register authorization info callbacks.");
+			goto end;
+		}
 	}
 
 	ret = bt_enable(NULL);

--- a/samples/zigbee/light_switch/src/nus_cmd.c
+++ b/samples/zigbee/light_switch/src/nus_cmd.c
@@ -31,6 +31,9 @@ security_changed(struct bt_conn *conn, bt_security_t level,
 static struct bt_conn_auth_cb conn_auth_callbacks = {
 	.passkey_display = auth_passkey_display,
 	.cancel = auth_cancel,
+};
+
+static struct bt_conn_auth_info_cb conn_auth_info_callbacks = {
 	.pairing_complete = pairing_complete,
 	.pairing_failed = pairing_failed
 };
@@ -144,7 +147,17 @@ static int ble_utils_init(struct bt_nus_cb *nus_clbs,
 	bt_conn_cb_register(&conn_callbacks);
 
 	if (IS_ENABLED(CONFIG_BT_SMP)) {
-		bt_conn_auth_cb_register(&conn_auth_callbacks);
+		ret = bt_conn_auth_cb_register(&conn_auth_callbacks);
+		if (ret) {
+			LOG_ERR("Failed to register authorization callbacks.");
+			goto end;
+		}
+
+		ret = bt_conn_auth_info_cb_register(&conn_auth_info_callbacks);
+		if (ret) {
+			LOG_ERR("Failed to register authorization info callbacks.");
+			goto end;
+		}
 	}
 
 	ret = bt_enable(NULL);


### PR DESCRIPTION
The information-only callbacks have been separated out.

Signed-off-by: Herman Berget <herman.berget@nordicsemi.no>