### PR TITLE
mpsl: mpsl_fem: Remove direct SPI pin control

### DIFF
--- a/modules/tfm/zephyr/Kconfig
+++ b/modules/tfm/zephyr/Kconfig
@@ -17,6 +17,7 @@ if BUILD_WITH_TFM
 
 config TFM_SECURE_UART1
 	bool
+	depends on $(dt_nodelabel_has_compat,uarte1,$(DT_COMPAT_NORDIC_NRF_UARTE))
 	select NRF_UARTE1_SECURE
 
 endif # BUILD_WITH_TFM

--- a/samples/bluetooth/mesh/light_ctrl/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/mesh/light_ctrl/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -1,5 +1,22 @@
 &pwm0 {
 	status = "okay";
-	ch0-pin = <28>;
-	ch0-inverted;
+	pinctrl-0 = <&pwm0_default_alt>;
+	pinctrl-1 = <&pwm0_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+};
+
+&pinctrl {
+	pwm0_default_alt: pwm0_default_alt {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 28)>;
+			nordic,invert;
+		};
+	};
+
+	pwm0_sleep_alt: pwm0_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 28)>;
+			low-power-enable;
+		};
+	};
 };

--- a/samples/bluetooth/mesh/light_ctrl/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
+++ b/samples/bluetooth/mesh/light_ctrl/boards/nrf5340dk_nrf5340_cpuapp_ns.overlay
@@ -1,5 +1,22 @@
 &pwm0 {
 	status = "okay";
-	ch0-pin = <28>;
-	ch0-inverted;
+	pinctrl-0 = <&pwm0_default_alt>;
+	pinctrl-1 = <&pwm0_sleep_alt>;
+	pinctrl-names = "default", "sleep";
+};
+
+&pinctrl {
+	pwm0_default_alt: pwm0_default_alt {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 28)>;
+			nordic,invert;
+		};
+	};
+
+	pwm0_sleep_alt: pwm0_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 28)>;
+			low-power-enable;
+		};
+	};
 };

--- a/subsys/mpsl/fem/mpsl_fem.c
+++ b/subsys/mpsl/fem/mpsl_fem.c
@@ -310,43 +310,6 @@ static int fem_nrf21540_gpio_configure(void)
 	}
 #endif
 
-#if DT_NODE_HAS_STATUS(MPSL_FEM_SPI_IF, okay)
-	err = inactive_pin_configure(
-		DT_PROP(DT_BUS(DT_NODELABEL(nrf_radio_fem_spi)), sck_pin),
-		NULL,
-		0);
-
-	if (err) {
-		return err;
-	}
-
-	err = inactive_pin_configure(
-		DT_PROP(DT_BUS(DT_NODELABEL(nrf_radio_fem_spi)), miso_pin),
-		NULL,
-		0);
-
-	if (err) {
-		return err;
-	}
-
-	err = inactive_pin_configure(
-		DT_PROP(DT_BUS(DT_NODELABEL(nrf_radio_fem_spi)), mosi_pin),
-		NULL,
-		0);
-
-	if (err) {
-		return err;
-	}
-
-	err = inactive_pin_configure(
-		DT_SPI_DEV_CS_GPIOS_PIN(MPSL_FEM_SPI_IF),
-		DT_SPI_DEV_CS_GPIOS_LABEL(MPSL_FEM_SPI_IF),
-		DT_SPI_DEV_CS_GPIOS_FLAGS(MPSL_FEM_SPI_IF));
-
-	if (err) {
-		return err;
-	}
-#endif
 	(void)err;
 
 	return mpsl_fem_nrf21540_gpio_interface_config_set(&cfg);


### PR DESCRIPTION
Removed direct SPI pin control as it is being handled
by the SPI driver and PINCTRL.

Signed-off-by: Piotr Sławęcki <piotr.slawecki@nordicsemi.no>