### PR TITLE
applications: serial_lte_modem: Switch overlays to PINCTRL

### DIFF
--- a/applications/serial_lte_modem/boards/nrf9160dk_nrf9160_ns.overlay
+++ b/applications/serial_lte_modem/boards/nrf9160dk_nrf9160_ns.overlay
@@ -8,13 +8,34 @@
 	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "disabled";
-	tx-pin = <10>;
-	rx-pin = <11>;
-	rts-pin = <12>;
-	cts-pin = <13>;
 	hw-flow-control;
+
+	pinctrl-0 = <&uart2_default_alt>;
+	pinctrl-1 = <&uart2_sleep_alt>;
+	pinctrl-names = "default", "sleep";
 };
 
 &i2c2 {
 	status = "disabled";
+};
+
+&pinctrl {
+	uart2_default_alt: uart2_default_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 10)>,
+				<NRF_PSEL(UART_RX, 0, 11)>,
+				<NRF_PSEL(UART_RTS, 0, 12)>,
+				<NRF_PSEL(UART_CTS, 0, 13)>;
+		};
+	};
+
+	uart2_sleep_alt: uart2_sleep_alt {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 10)>,
+				<NRF_PSEL(UART_RX, 0, 11)>,
+				<NRF_PSEL(UART_RTS, 0, 12)>,
+				<NRF_PSEL(UART_CTS, 0, 13)>;
+			low-power-enable;
+		};
+	};
 };


### PR DESCRIPTION
DTS overlays have been modifid to use PINCTRL

Signed-off-by: Andreas Moltumyr <andreas.moltumyr@nordicsemi.no>