### PR TITLE
doc: nrf: fix Zephyr include paths 

### DIFF
--- a/doc/nrf/gs_installing.rst
+++ b/doc/nrf/gs_installing.rst
@@ -47,7 +47,7 @@ The installation process is different depending on your operating system.
 
       To install the required tools, complete the following steps:
 
-      .. ncs-include:: getting_started/index.rst
+      .. ncs-include:: develop/getting_started/index.rst
          :docset: zephyr
          :dedent: 6
          :start-after: .. _install_dependencies_windows:
@@ -58,7 +58,7 @@ The installation process is different depending on your operating system.
 
       To install the required tools on Ubuntu, complete the following steps:
 
-      .. ncs-include:: getting_started/index.rst
+      .. ncs-include:: develop/getting_started/index.rst
          :docset: zephyr
          :dedent: 6
          :start-after: .. _install_dependencies_ubuntu:
@@ -76,7 +76,7 @@ The installation process is different depending on your operating system.
 
       To install the required tools, complete the following steps:
 
-      .. ncs-include:: getting_started/index.rst
+      .. ncs-include:: develop/getting_started/index.rst
          :docset: zephyr
          :dedent: 6
          :start-after: .. _install_dependencies_macos:

--- a/doc/nrf/gs_modifying.rst
+++ b/doc/nrf/gs_modifying.rst
@@ -141,7 +141,7 @@ To read more about Zephyr's configuration system, see :ref:`zephyr:build_overvie
 Hardware-related configuration
 ------------------------------
 
-.. ncs-include:: guides/build/index.rst
+.. ncs-include:: build/cmake/index.rst
    :docset: zephyr
    :dedent: 3
    :start-after: Devicetree
@@ -159,7 +159,7 @@ For more information, see Zephyr's :ref:`zephyr:dt-guide`.
 Software-related configuration
 ------------------------------
 
-.. ncs-include:: guides/build/index.rst
+.. ncs-include:: build/cmake/index.rst
    :docset: zephyr
    :dedent: 3
    :start-after: Kconfig

--- a/doc/nrf/templates/cheat_sheet.rst
+++ b/doc/nrf/templates/cheat_sheet.rst
@@ -253,11 +253,11 @@ Include 2:
 To reuse text from another doc set:
 
 Include 3:
-  .. ncs-include:: getting_started/installation_win.rst
+  .. ncs-include:: develop/getting_started/index.rst
      :docset: zephyr
      :auto-dedent:
-     :start-line: 10
-     :end-line: 18
+     :start-line: 6
+     :end-line: 16
 
 Include 4:
   .. ncs-include:: nfc/doc/type_2_tag.rst


### PR DESCRIPTION
Zephyr documentation has been recently re-organized, update ncs-include
directives so that they point to the new document location.