### PR TITLE
doc: releases: delete broken link from 0.3.0 release notes

### DIFF
--- a/doc/nrf/releases/release-notes-0.3.0.rst
+++ b/doc/nrf/releases/release-notes-0.3.0.rst
@@ -204,7 +204,7 @@ Documentation
 =============
 
 * Added :ref:`getting_started` information.
-* Added :ref:`user_guides` for working with nRF9160 samples, Enhanced ShockBurst (ESB), and the secure bootloader chain.
+* Added user guides for working with nRF9160 samples, Enhanced ShockBurst (ESB), and the secure bootloader chain.
 * Added documentation for various :ref:`samples` and :ref:`libraries`.
 * Added :doc:`MCUboot <mcuboot:index-ncs>` and :doc:`nrfxlib <nrfxlib:README>` documentation.
 


### PR DESCRIPTION
The user guides section was re-structured by
f919637ed590496fda875d6c1c20767193183f3f, however, the reference
resolved anyway because Zephyr had the same one. Now that Zephyr has
also removed this one, it no longer resolves and generates a warning.