### PR TITLE
lib: at_monitor: increase system work queue default stack size

### DIFF
--- a/lib/at_monitor/Kconfig
+++ b/lib/at_monitor/Kconfig
@@ -14,6 +14,9 @@ config AT_MONITOR_HEAP_SIZE
 	range 64 2048
 	default 256
 
+config SYSTEM_WORKQUEUE_STACK_SIZE
+	default 1152 if (LTE_LINK_CONTROL && LOG)
+
 module=AT_MONITOR
 module-dep=LOG
 module-str= AT notification monitor library


### PR DESCRIPTION
Increased system work queue default stack size when LTE Link Control and logging are enabled.