### PR TITLE
samples: ipc: Fix dts configuration

### DIFF
--- a/samples/event_manager_proxy/boards/nrf5340dk_nrf5340_cpuapp_icmsg.overlay
+++ b/samples/event_manager_proxy/boards/nrf5340dk_nrf5340_cpuapp_icmsg.overlay
@@ -23,22 +23,6 @@
 		};
 	};
 
-	soc {
-		peripheral@50000000 {
-			/delete-node/ ipc@2a000;
-
-			mbox: mbox@2a000 {
-				compatible = "nordic,mbox-nrf-ipc";
-				reg = <0x2a000 0x1000>;
-				tx-mask = <0x0000ffff>;
-				rx-mask = <0x0000ffff>;
-				interrupts = <42 NRF_DEFAULT_IRQ_PRIORITY>;
-				#mbox-cells = <1>;
-				status = "okay";
-			};
-		};
-	};
-
 	ipc0: ipc0 {
 		compatible = "zephyr,ipc-icmsg";
 		tx-region = <&sram_tx>;

--- a/samples/event_manager_proxy/remote/boards/nrf5340dk_nrf5340_cpunet_icmsg.overlay
+++ b/samples/event_manager_proxy/remote/boards/nrf5340dk_nrf5340_cpunet_icmsg.overlay
@@ -23,20 +23,6 @@
 		};
 	};
 
-	soc {
-		/delete-node/ ipc@41012000;
-
-		mbox: mbox@41012000 {
-			compatible = "nordic,mbox-nrf-ipc";
-			reg = <0x41012000 0x1000>;
-			tx-mask = <0x0000ffff>;
-			rx-mask = <0x0000ffff>;
-			interrupts = <18 NRF_DEFAULT_IRQ_PRIORITY>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
-	};
-
 	ipc0: ipc0 {
 		compatible = "zephyr,ipc-icmsg";
 		tx-region = <&sram_tx>;

--- a/samples/ipc/ipc_service/icmsg.overlay
+++ b/samples/ipc/ipc_service/icmsg.overlay
@@ -23,22 +23,6 @@
 		};
 	};
 
-	soc {
-		peripheral@50000000 {
-			/delete-node/ ipc@2a000;
-
-			mbox: mbox@2a000 {
-				compatible = "nordic,mbox-nrf-ipc";
-				reg = <0x2a000 0x1000>;
-				tx-mask = <0x0000ffff>;
-				rx-mask = <0x0000ffff>;
-				interrupts = <42 NRF_DEFAULT_IRQ_PRIORITY>;
-				#mbox-cells = <1>;
-				status = "okay";
-			};
-		};
-	};
-
 	ipc0: ipc0 {
 		compatible = "zephyr,ipc-icmsg";
 		tx-region = <&sram_tx>;

--- a/samples/ipc/ipc_service/remote/icmsg.overlay
+++ b/samples/ipc/ipc_service/remote/icmsg.overlay
@@ -23,20 +23,6 @@
 		};
 	};
 
-	soc {
-		/delete-node/ ipc@41012000;
-
-		mbox: mbox@41012000 {
-			compatible = "nordic,mbox-nrf-ipc";
-			reg = <0x41012000 0x1000>;
-			tx-mask = <0x0000ffff>;
-			rx-mask = <0x0000ffff>;
-			interrupts = <18 NRF_DEFAULT_IRQ_PRIORITY>;
-			#mbox-cells = <1>;
-			status = "okay";
-		};
-	};
-
 	ipc0: ipc0 {
 		compatible = "zephyr,ipc-icmsg";
 		tx-region = <&sram_tx>;


### PR DESCRIPTION
This commit fixes an issue of undefined reference to
some IPC nrfx functions. This issue happened when
ipc-service was compiled with icmsg backend.

The samples fixed in this commit were unnecessarily
redefining mbox node. In the defaul node definition
two compatibles are present:
"nordic,mbox-nrf-ipc" and "nordic,nrf-ipc"

Based on "nordic,nrf-ipc" driver that defines missing
functions was not included in the build.

This issue could be fixed by adding missing compatible,
however redefinition of mbox node was not necessary in
the first place, thus remove it.

With this patch, the default mbox node definition is used
and it uses both required compatibles.

Signed-off-by: Emil Obalski <emil.obalski@nordicsemi.no>