### PR TITLE
boards: nrf52: Suppress DTC warnings about duplicate unit-address

### DIFF
--- a/boards/arm/nrf52810dmouse_nrf52810/pre_dt_board.cmake
+++ b/boards/arm/nrf52810dmouse_nrf52810/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - power@40000000 & clock@40000000 & bprot@40000000
+# - acl@4001e000 & flash-controller@4001e000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/nrf52820dongle_nrf52820/pre_dt_board.cmake
+++ b/boards/arm/nrf52820dongle_nrf52820/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - power@40000000 & clock@40000000 & bprot@40000000
+# - acl@4001e000 & flash-controller@4001e000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/nrf52833dongle_nrf52833/pre_dt_board.cmake
+++ b/boards/arm/nrf52833dongle_nrf52833/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - power@40000000 & clock@40000000 & bprot@40000000
+# - acl@4001e000 & flash-controller@4001e000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/nrf52840gmouse_nrf52840/pre_dt_board.cmake
+++ b/boards/arm/nrf52840gmouse_nrf52840/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - power@40000000 & clock@40000000 & bprot@40000000
+# - acl@4001e000 & flash-controller@4001e000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")

--- a/boards/arm/nrf52kbd_nrf52832/pre_dt_board.cmake
+++ b/boards/arm/nrf52kbd_nrf52832/pre_dt_board.cmake
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+# Suppress "unique_unit_address_if_enabled" to handle the following overlaps:
+# - power@40000000 & clock@40000000 & bprot@40000000
+# - acl@4001e000 & flash-controller@4001e000
+list(APPEND EXTRA_DTC_FLAGS "-Wno-unique_unit_address_if_enabled")


### PR DESCRIPTION
Prevent "unique_unit_address_if_enabled" warnings from being reported
for nRF52 Series SoCs, where certain nodes need to be enabled with
the same base addresses. These can be (depending on a given SoC):
- power@40000000 & clock@40000000
- power@40000000 & clock@40000000 & bprot@40000000
- acl@4001e000 & flash-controller@4001e000

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>