### PR TITLE
net: lib: coap_utils: Depend upon COAP

### DIFF
--- a/doc/nrf/libraries/networking/coap_utils.rst
+++ b/doc/nrf/libraries/networking/coap_utils.rst
@@ -26,7 +26,7 @@ Currently, the library only supports the User Datagram Protocol (UDP) protocol.
 Configuration
 *************
 
-To enable the CoAP utils library, set the :kconfig:option:`CONFIG_COAP_UTILS` Kconfig option.
+To enable the CoAP utils library, set the :kconfig:option:`CONFIG_COAP` and :kconfig:option:`CONFIG_COAP_UTILS` Kconfig options.
 
 API documentation
 *****************

--- a/subsys/net/lib/coap_utils/Kconfig
+++ b/subsys/net/lib/coap_utils/Kconfig
@@ -5,8 +5,7 @@
 #
 config COAP_UTILS
 	bool "Support for communication with CoAP"
-	select COAP
-	depends on NET_SOCKETS
+	depends on COAP
 	help
 	  Send and receive CoAP non-confirmable requests.
 	  Utilize CoAP and Modem libraries.


### PR DESCRIPTION
Prevents a Kconfig loop by making this option just depend upon COAP being enabled