### PR TITLE
samples: cellular: modem_shell: Make shell UART interrupt driven

### DIFF
--- a/samples/cellular/modem_shell/prj.conf
+++ b/samples/cellular/modem_shell/prj.conf
@@ -34,6 +34,8 @@ CONFIG_SHELL_CMD_BUFF_SIZE=3584
 CONFIG_SHELL_STACK_SIZE=9216
 # Shell RX buffer needs to be increased to avoid problems with test automation
 CONFIG_SHELL_BACKEND_SERIAL_RX_RING_BUFFER_SIZE=512
+# Use interrupt driven shell UART, otherwise we won't be able to suspend the UART
+CONFIG_SHELL_BACKEND_SERIAL_API_INTERRUPT_DRIVEN=y
 # LTE shell is unnecessary with Modem Shell
 CONFIG_LTE_SHELL=n
 # Enable use of vsnprintfcb() for extending mosh_print() format


### PR DESCRIPTION
Explicitly set shell UART into interrupt driven mode, otherwise upstream changes will cause asynchronous mode to be selected. Suspending the shell UART only works in interrupt driven mode.