### PR TITLE
mpsl: Update anomaly 109 workaround's default EGU instance

### DIFF
--- a/subsys/mpsl/init/Kconfig
+++ b/subsys/mpsl/init/Kconfig
@@ -10,6 +10,13 @@ config MPSL_THREAD_COOP_PRIO
 	default BT_CTLR_SDC_RX_PRIO if BT_LL_SOFTDEVICE
 	default 8
 
+config NRF52_ANOMALY_109_WORKAROUND_EGU_INSTANCE
+	depends on NRF52_ANOMALY_109_WORKAROUND
+	default 4
+	help
+	  Update default EGU instance used by the nRF52 Anomaly 109 workaround
+	  for PWM. The EGU instance 5 is used by the MPSL.
+
 config MPSL_WORK_STACK_SIZE
 	int "Size of the work handler thread stack"
 	default 1024

--- a/subsys/mpsl/init/mpsl_init.c
+++ b/subsys/mpsl/init/mpsl_init.c
@@ -36,6 +36,10 @@ static K_WORK_DELAYABLE_DEFINE(calibration_work, mpsl_calibration_work_handler);
 extern void rtc_pretick_rtc0_isr_hook(void);
 
 #if IS_ENABLED(CONFIG_SOC_COMPATIBLE_NRF52X)
+	#if IS_ENABLED(CONFIG_NRF52_ANOMALY_109_WORKAROUND)
+		BUILD_ASSERT(CONFIG_NRF52_ANOMALY_109_WORKAROUND_EGU_INSTANCE != 5,
+			     "MPSL uses EGU instance 5, please use another one");
+	#endif
 	#define MPSL_LOW_PRIO_IRQn SWI5_IRQn
 #elif IS_ENABLED(CONFIG_SOC_SERIES_NRF53X)
 	#define MPSL_LOW_PRIO_IRQn SWI0_IRQn


### PR DESCRIPTION
Set default of CONFIG_NRF52_ANOMALY_109_WORKAROUND_EGU_INSTANCE to 4. The EGU instance 5 is already used by the MPSL for MPSL_LOW_PRIO_IRQn.

Jira: NCSDK-24735