### PR TITLE
applications: nrf_desktop: Fix CONTAINER_OF usage for selector_hw

### DIFF
--- a/applications/nrf_desktop/src/hw_interface/selector_hw.c
+++ b/applications/nrf_desktop/src/hw_interface/selector_hw.c
@@ -147,6 +147,7 @@ static void selector_isr(const struct device *dev, struct gpio_callback *cb,
 {
 	struct selector *sel;
 	size_t port;
+	uint8_t *ptr;
 
 	for (port = 0; port < ARRAY_SIZE(gpio_dev); port++) {
 		if (dev == gpio_dev[port]) {
@@ -155,7 +156,8 @@ static void selector_isr(const struct device *dev, struct gpio_callback *cb,
 	}
 	__ASSERT_NO_MSG(port != ARRAY_SIZE(gpio_dev));
 
-	sel = CONTAINER_OF((uint8_t *)cb - port * sizeof(sel->gpio_cb[0]),
+	ptr = (uint8_t *)cb - port * sizeof(sel->gpio_cb[0]);
+	sel = CONTAINER_OF((struct gpio_callback (*)[])ptr,
 			   struct selector,
 			   gpio_cb);
 	disable_interrupts_nolock(sel);


### PR DESCRIPTION
Change fixes CONTAINER_OF macro usage for selector_hw module. The fix prevents build failures triggered by BUILD_ASSERT failure.

Jira: NCSDK-24735