### PR TITLE
samples: bluetooth: mesh: move emds interrupt to 26

### DIFF
--- a/samples/bluetooth/mesh/light_ctrl/src/main.c
+++ b/samples/bluetooth/mesh/light_ctrl/src/main.c
@@ -21,7 +21,7 @@
 #include <mpsl/mpsl_lib.h>
 #endif
 
-#define EMDS_DEV_IRQ 24
+#define EMDS_DEV_IRQ 26
 #define EMDS_DEV_PRIO 0
 #define EMDS_ISR_ARG 0
 #define EMDS_IRQ_FLAGS 0


### PR DESCRIPTION
Changing the interrupt line used by emds to remove conflict that happens for nrf52832 when emds enabled.