### PR TITLE
samples: cellular: modem_trace_backend: rework libc float dependency

### DIFF
--- a/samples/cellular/modem_trace_backend/Kconfig.trace_print_stats
+++ b/samples/cellular/modem_trace_backend/Kconfig.trace_print_stats
@@ -13,8 +13,7 @@ config NRF_MODEM_LIB_TRACE_BACKEND_CUSTOM
 	bool "Count modem traces and print to terminal"
 	depends on CPU_LOAD
 	depends on FPU
-	imply NEWLIB_LIBC_FLOAT_PRINTF if NEWLIB_LIBC
-	imply PICOLIBC_IO_FLOAT if PICOLIBC
+	depends on NEWLIB_LIBC_FLOAT_PRINTF || PICOLIBC_IO_FLOAT
 	help
 	  Print modem trace data statistics
 	  and cpu utilization.


### PR DESCRIPTION
Rework libc float dependency as PICOLIBC_IO_FLOAT is now a choice selection and cannot be selected or implied.